### PR TITLE
Update to use corpus item data

### DIFF
--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -68,8 +68,6 @@ async function getData(): Promise<ClientApiResponse | null> {
             recommendations {
               item {
                 resolvedUrl
-                title
-                topImageUrl
                 timeToRead
                 domainMetadata {
                   name
@@ -78,6 +76,10 @@ async function getData(): Promise<ClientApiResponse | null> {
                   publisher {
                     name
                   }
+                }
+                corpusItem {
+                  title
+                  imageUrl
                 }
               }
             }

--- a/src/lib.spec.ts
+++ b/src/lib.spec.ts
@@ -33,10 +33,6 @@ describe('test lib', () => {
       item = {
         resolvedUrl:
           'https://getpocket.com/explore/item/7-incredible-benefits-of-lifting-weights-that-have-nothing-to-do-with-building-muscle',
-        title:
-          '7 Incredible Benefits of Lifting Weights That Have Nothing to Do With Building Muscle',
-        topImageUrl:
-          'https://pocket-image-cache.com/1200x/filters:format(jpg):extract_focal()/https%3A%2F%2Fpocket-syndicated-images.s3.amazonaws.com%2Farticles%2F6786%2F1628710235_61141fc464340.png',
         timeToRead: 6,
         domainMetadata: {
           name: 'Pocket',
@@ -44,6 +40,12 @@ describe('test lib', () => {
         // normally a value of 'Pocket' above would dictate syndication data -
         // omitting here for testing purposes.
         syndicatedArticle: null,
+        corpusItem: {
+          title:
+            '7 Incredible Benefits of Lifting Weights That Have Nothing to Do With Building Muscle',
+          imageUrl:
+            'https://pocket-image-cache.com/1200x/filters:format(jpg):extract_focal()/https%3A%2F%2Fpocket-syndicated-images.s3.amazonaws.com%2Farticles%2F6786%2F1628710235_61141fc464340.png',
+        },
       };
     });
 
@@ -91,26 +93,30 @@ describe('test lib', () => {
       rawRec1 = {
         item: {
           resolvedUrl: url1,
-          title: title1,
-          topImageUrl: imageUrl1,
           timeToRead: ttr1,
           domainMetadata: {
             name: publisher1,
           },
           syndicatedArticle: null,
+          corpusItem: {
+            title: title1,
+            imageUrl: imageUrl1,
+          },
         },
       };
 
       rawRec2 = {
         item: {
           resolvedUrl: url2,
-          title: title2,
-          topImageUrl: imageUrl2,
           timeToRead: ttr2,
           domainMetadata: {
             name: publisher2,
           },
           syndicatedArticle: null,
+          corpusItem: {
+            title: title2,
+            imageUrl: imageUrl2,
+          },
         },
       };
     });

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -24,8 +24,8 @@ export function transformSlateRecs(
     rec = {
       category,
       url: rawRec.item.resolvedUrl,
-      title: rawRec.item.title,
-      imageUrl: buildCdnImageUrl(rawRec.item.topImageUrl),
+      title: rawRec.item.corpusItem.title,
+      imageUrl: buildCdnImageUrl(rawRec.item.corpusItem.imageUrl),
       // item.domainMetadata.name is either the proper name ("New York Times")
       // or the root domain ("nytimes.com")
       publisher: derivePublisher(rawRec.item),

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,13 +32,17 @@ export type ClientApiSyndicatedArticle = {
   };
 };
 
+export type ClientApiCorpusItem = {
+  title: string;
+  imageUrl: string;
+};
+
 export type ClientApiItem = {
   resolvedUrl: string;
-  title: string;
-  topImageUrl: string;
   timeToRead: number | null;
   domainMetadata: ClientApiDomainMeta | null;
   syndicatedArticle: ClientApiSyndicatedArticle | null;
+  corpusItem: ClientApiCorpusItem;
 };
 
 export type ClientApiRecommendation = {


### PR DESCRIPTION
## Summary
- use `corpusItem` title and image for recommendations
- adjust GraphQL query and types
- update unit tests

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841b25fc73883288367cb4647edae72