### PR TITLE
Use corpusItem fields for recommendations

### DIFF
--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -67,9 +67,8 @@ async function getData(): Promise<ClientApiResponse | null> {
             id
             recommendations {
               item {
+                id
                 resolvedUrl
-                title
-                topImageUrl
                 timeToRead
                 domainMetadata {
                   name
@@ -78,6 +77,10 @@ async function getData(): Promise<ClientApiResponse | null> {
                   publisher {
                     name
                   }
+                }
+                corpusItem {
+                  title
+                  imageUrl
                 }
               }
             }

--- a/src/lib.spec.ts
+++ b/src/lib.spec.ts
@@ -33,10 +33,7 @@ describe('test lib', () => {
       item = {
         resolvedUrl:
           'https://getpocket.com/explore/item/7-incredible-benefits-of-lifting-weights-that-have-nothing-to-do-with-building-muscle',
-        title:
-          '7 Incredible Benefits of Lifting Weights That Have Nothing to Do With Building Muscle',
-        topImageUrl:
-          'https://pocket-image-cache.com/1200x/filters:format(jpg):extract_focal()/https%3A%2F%2Fpocket-syndicated-images.s3.amazonaws.com%2Farticles%2F6786%2F1628710235_61141fc464340.png',
+        id: 'item-1',
         timeToRead: 6,
         domainMetadata: {
           name: 'Pocket',
@@ -44,6 +41,12 @@ describe('test lib', () => {
         // normally a value of 'Pocket' above would dictate syndication data -
         // omitting here for testing purposes.
         syndicatedArticle: null,
+        corpusItem: {
+          title:
+            '7 Incredible Benefits of Lifting Weights That Have Nothing to Do With Building Muscle',
+          imageUrl:
+            'https://pocket-image-cache.com/1200x/filters:format(jpg):extract_focal()/https%3A%2F%2Fpocket-syndicated-images.s3.amazonaws.com%2Farticles%2F6786%2F1628710235_61141fc464340.png',
+        },
       };
     });
 
@@ -91,26 +94,32 @@ describe('test lib', () => {
       rawRec1 = {
         item: {
           resolvedUrl: url1,
-          title: title1,
-          topImageUrl: imageUrl1,
+          id: 'raw1',
           timeToRead: ttr1,
           domainMetadata: {
             name: publisher1,
           },
           syndicatedArticle: null,
+          corpusItem: {
+            title: title1,
+            imageUrl: imageUrl1,
+          },
         },
       };
 
       rawRec2 = {
         item: {
           resolvedUrl: url2,
-          title: title2,
-          topImageUrl: imageUrl2,
+          id: 'raw2',
           timeToRead: ttr2,
           domainMetadata: {
             name: publisher2,
           },
           syndicatedArticle: null,
+          corpusItem: {
+            title: title2,
+            imageUrl: imageUrl2,
+          },
         },
       };
     });

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -24,8 +24,8 @@ export function transformSlateRecs(
     rec = {
       category,
       url: rawRec.item.resolvedUrl,
-      title: rawRec.item.title,
-      imageUrl: buildCdnImageUrl(rawRec.item.topImageUrl),
+      title: rawRec.item.corpusItem.title,
+      imageUrl: buildCdnImageUrl(rawRec.item.corpusItem.imageUrl),
       // item.domainMetadata.name is either the proper name ("New York Times")
       // or the root domain ("nytimes.com")
       publisher: derivePublisher(rawRec.item),

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,11 +34,14 @@ export type ClientApiSyndicatedArticle = {
 
 export type ClientApiItem = {
   resolvedUrl: string;
-  title: string;
-  topImageUrl: string;
+  id: string;
   timeToRead: number | null;
   domainMetadata: ClientApiDomainMeta | null;
   syndicatedArticle: ClientApiSyndicatedArticle | null;
+  corpusItem: {
+    title: string;
+    imageUrl: string;
+  };
 };
 
 export type ClientApiRecommendation = {


### PR DESCRIPTION
## Summary
- update GraphQL query to request `corpusItem` data
- expose new fields in `ClientApiItem`
- map title and image URL from `corpusItem`
- adjust tests for new shape

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c88dbda88328b2f039da2e6c917a